### PR TITLE
Fix PHP warning: array offset on null in youtube embed render filter

### DIFF
--- a/src/Integrations/Embeds.php
+++ b/src/Integrations/Embeds.php
@@ -29,7 +29,7 @@ class Embeds
             return $block_content;
         }
 
-        if ($block['blockName'] === 'core-embed/youtube') {
+        if (($block['blockName'] ?? null) === 'core-embed/youtube') {
             $block_content = str_replace('youtube.com', 'youtube-nocookie.com', $block_content);
         }
 


### PR DESCRIPTION
Fixes a recurring PHP warning seen in Kinsta production logs (site **britamariarenlund** / bmr.fi, PHP 8.2).

## Warning

```
PHP Warning: Trying to access array offset on value of type null
in .../app/plugins/genero-cmp/src/Plugin.php on line 91
```

It fired during block rendering (e.g. on `/tag/*/feed/`, `/category/*/feed/` requests), alongside the usual WordPress core block-render null-offset warnings.

## Root cause

The deployed site runs an older `genero-cmp` (1.x) where `Plugin.php:91` is the `render_block` filter callback `overrideYoutubeEmbeds()`:

```php
if (core-embed/youtube === $block[blockName]) {
```

When `$block` (or its `blockName` offset) is null/missing, accessing `$block[blockName]` triggers `Trying to access array offset on value of type null`.

That code has since moved (unchanged in substance) to `Embeds::changeYoutubeEmbedDomain()` in `src/Integrations/Embeds.php`, which is the equivalent location on `master`.

## Fix

Guard the offset access with a null coalesce so null/non-block content passed through the `render_block` filter no longer triggers the warning:

```php
if (($block[blockName] ?? null) === core-embed/youtube) {
```

Matches the null-safe style used elsewhere in the codebase (`$options[$option] ?? null`, `$this->settings[tcfapi] ?? false`).

## Verification

- `php -l` clean
- `composer test` (phpcs) passes on the changed file

🤖 Generated with [Claude Code](https://claude.com/claude-code)